### PR TITLE
Bugfix/update coloring problem

### DIFF
--- a/src/main/java/org/aksw/sessa/helper/graph/Node.java
+++ b/src/main/java/org/aksw/sessa/helper/graph/Node.java
@@ -184,6 +184,15 @@ public class Node<T> {
     return false;
   }
 
+  public boolean colorsAreMergeable(Set<NGramEntryPosition> otherColors) {
+    for (NGramEntryPosition color : this.colors) {
+      if (!color.isMergeable(otherColors)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /**
    * Compares the specified object with this node for equality. Returns true if the given object is
    * also a Node and has the same content and the same id.

--- a/src/main/java/org/aksw/sessa/helper/graph/Node.java
+++ b/src/main/java/org/aksw/sessa/helper/graph/Node.java
@@ -120,12 +120,20 @@ public class Node<T> {
    * Adds a color to this node. Colors are represented by n-gram-positions in the n-gram hierarchy.
    * They show which n-grams were used to explain the content of this node.
    *
-   * @param color position of the n-gram in the n-gram hierarchy
+   * @param otherColor position of the n-gram in the n-gram hierarchy
    * @see NGramEntryPosition
    */
-  public void addColor(NGramEntryPosition color) {
-    this.colors.add(color);
-    updateExplanation(color);
+  public void addColor(NGramEntryPosition otherColor) {
+    Set<NGramEntryPosition> removeColors = new HashSet<>();
+    for (NGramEntryPosition color : colors) {
+      if (color.isOverlappingWith(otherColor)) {
+        if (otherColor.getLength() > color.getLength()) {
+          removeColors.add(color);
+        }
+      }
+    }
+    colors.removeAll(removeColors);
+    this.colors.add(otherColor);
   }
 
   /**
@@ -135,8 +143,9 @@ public class Node<T> {
    * @see #addColor(NGramEntryPosition)
    */
   public void addColors(Set<NGramEntryPosition> colors) {
-    this.colors.addAll(colors);
-    updateExplanation(colors);
+    for (NGramEntryPosition color : colors) {
+      addColor(color);
+    }
   }
 
   /**

--- a/src/main/java/org/aksw/sessa/helper/graph/Node.java
+++ b/src/main/java/org/aksw/sessa/helper/graph/Node.java
@@ -54,7 +54,7 @@ public class Node<T> {
   }
 
   /**
-   * Returns the explanation score of this node. For explanation of this score see {@link
+   * Returns the explanation score of this node.
    */
   public int getExplanation() {
     int explanation = 0;
@@ -76,8 +76,8 @@ public class Node<T> {
 
   /**
    * Sets the energy score for this node. The energy score is another score that tries to explain
-   * how good trustworthy the n-gram mapping to the content is. E.g. this can be realized via
-   * Levenshtein distance.
+   * how trustworthy the n-gram mapping to the content is. E.g. this can be realized via Levenshtein
+   * distance.
    */
   public void setEnergy(float newEnergy) {
     energy = newEnergy;
@@ -143,10 +143,16 @@ public class Node<T> {
     return isFactNode;
   }
 
+  /**
+   * Returns ID of this node
+   */
   long getId() {
     return id;
   }
 
+  /**
+   * Generates a random new ID for this node.
+   */
   public void newId() {
     id = new Random().nextLong();
   }
@@ -169,6 +175,13 @@ public class Node<T> {
     return false;
   }
 
+  /**
+   * Checks if colors of this node are mergeable with the given colors. Colors are mergeable if they
+   * either don't overlap or are related.
+   *
+   * @param otherColors colors which should be check for mergeablity
+   * @return true if colors are mergeable, false if they aren't
+   */
   public boolean colorsAreMergeable(Set<NGramEntryPosition> otherColors) {
     for (NGramEntryPosition color : this.colors) {
       if (!color.isMergeable(otherColors)) {
@@ -215,7 +228,8 @@ public class Node<T> {
    */
   @Override
   public String toString() {
-    return "Node{" + "nodeContent=" + nodeContent + ", explanation=" + getExplanation()
+    return "Node{" + "nodeContent=" + nodeContent + ", id=" + getId() + ", explanation="
+        + getExplanation()
         + ", energy="
         + energy + ", colors=" + colors + ", isFactNode=" + isFactNode + '}';
   }

--- a/src/main/java/org/aksw/sessa/helper/graph/Node.java
+++ b/src/main/java/org/aksw/sessa/helper/graph/Node.java
@@ -25,10 +25,7 @@ public class Node<T> {
    * @param nodeContent content to be stored in the node
    */
   public Node(T nodeContent) {
-    this.nodeContent = nodeContent;
-    this.energy = 0;
-    this.colors = new HashSet<>();
-    this.isFactNode = false;
+    this(nodeContent, 0, new HashSet<>(), false);
   }
 
   /**

--- a/src/main/java/org/aksw/sessa/helper/graph/Node.java
+++ b/src/main/java/org/aksw/sessa/helper/graph/Node.java
@@ -14,7 +14,6 @@ public class Node<T> {
   private T nodeContent;
   private long id;
 
-  private int explanation;
   private float energy;
   private Set<NGramEntryPosition> colors;
   private boolean isFactNode;
@@ -27,7 +26,6 @@ public class Node<T> {
    */
   public Node(T nodeContent) {
     this.nodeContent = nodeContent;
-    this.explanation = 0;
     this.energy = 0;
     this.colors = new HashSet<>();
     this.isFactNode = false;
@@ -45,8 +43,6 @@ public class Node<T> {
     this.nodeContent = nodeContent;
     this.energy = energy;
     this.colors = colors;
-    this.explanation = 0;
-    updateExplanation(colors);
     this.isFactNode = isFactNode;
   }
 
@@ -59,35 +55,15 @@ public class Node<T> {
 
   /**
    * Returns the explanation score of this node. For explanation of this score see {@link
-   * #updateExplanation(NGramEntryPosition)}}.
    */
   public int getExplanation() {
+    int explanation = 0;
+    for (NGramEntryPosition color : colors) {
+      explanation += color.getLength();
+    }
     return explanation;
   }
 
-  /**
-   * Updates the explanation score for this node.
-   *
-   * @param colors newly added colors, with which the explanation will be updated
-   * @see #updateExplanation(NGramEntryPosition)
-   */
-  private void updateExplanation(Set<NGramEntryPosition> colors) {
-    for (NGramEntryPosition color : colors) {
-      updateExplanation(color);
-    }
-  }
-
-  /**
-   * Updates the explanation score for this node. The explanation score provides information on how
-   * many uni-grams this node is build on. E.g. this node might hold content about Bill Gates and is
-   * explained by the uni-grams "bill" & "gates" and therefore has an explanation score of 2.
-   *
-   * @param color newly added color, with which the explanation will be updated
-   */
-  private void updateExplanation(NGramEntryPosition color) {
-    // length of a colors equals number of represented n-grams
-    this.explanation += color.getLength();
-  }
 
   /**
    * Returns the energy score of this node.
@@ -239,7 +215,8 @@ public class Node<T> {
    */
   @Override
   public String toString() {
-    return "Node{" + "nodeContent=" + nodeContent + ", explanation=" + explanation + ", energy="
+    return "Node{" + "nodeContent=" + nodeContent + ", explanation=" + getExplanation()
+        + ", energy="
         + energy + ", colors=" + colors + ", isFactNode=" + isFactNode + '}';
   }
 }

--- a/src/main/java/org/aksw/sessa/helper/graph/Node.java
+++ b/src/main/java/org/aksw/sessa/helper/graph/Node.java
@@ -1,6 +1,7 @@
 package org.aksw.sessa.helper.graph;
 
 import java.util.HashSet;
+import java.util.Random;
 import java.util.Set;
 import org.aksw.sessa.query.models.NGramEntryPosition;
 
@@ -11,6 +12,7 @@ import org.aksw.sessa.query.models.NGramEntryPosition;
 public class Node<T> {
 
   private T nodeContent;
+  private long id;
 
   private int explanation;
   private float energy;
@@ -156,6 +158,14 @@ public class Node<T> {
     return isFactNode;
   }
 
+  long getId() {
+    return id;
+  }
+
+  public void newId() {
+    id = new Random().nextLong();
+  }
+
   /**
    * Checks if the color of this node and the other are overlapping. I.e. if they share a color or
    * if they share a descendant of a color.
@@ -176,7 +186,7 @@ public class Node<T> {
 
   /**
    * Compares the specified object with this node for equality. Returns true if the given object is
-   * also a Node and has the same content.
+   * also a Node and has the same content and the same id.
    *
    * @param other object to be compared for equality with this node
    * @return true if the specified object is equal to this node
@@ -184,7 +194,8 @@ public class Node<T> {
   @Override
   public boolean equals(Object other) {
     if (other instanceof Node<?>) {
-      if (((Node<?>) other).getContent().equals(this.nodeContent)) {
+      if (((Node<?>) other).getContent().equals(this.nodeContent) &&
+          ((Node<?>) other).getId() == this.getId()) {
         return true;
       }
     }

--- a/src/main/java/org/aksw/sessa/helper/graph/SelfBuildingGraph.java
+++ b/src/main/java/org/aksw/sessa/helper/graph/SelfBuildingGraph.java
@@ -56,7 +56,7 @@ public class SelfBuildingGraph implements GraphInterface {
     this.lastNewNodes = new HashMap<>();
     this.edgeMap = new HashMap<>();
     this.reversedEdgeMap = new HashMap<>();
-    for(Node node : nodes){
+    for (Node node : nodes) {
       this.nodes.put(node, node);
       this.lastNewNodes.put(node, node);
     }
@@ -178,26 +178,26 @@ public class SelfBuildingGraph implements GraphInterface {
               for (String content : newContent) {
                 Node<String> foundNode = new Node<>(content);
                 log.debug("SPARQL found new node {}", foundNode.getContent());
-                if(newNodes.containsKey(foundNode)){
-                  foundNode = newNodes.get(foundNode);
-                  log.debug("Node was already found this round.");
+                if (newNodes.containsKey(foundNode) || nodes.containsKey(foundNode)) {
+                  if (newNodes.containsKey(foundNode)) {
+                    foundNode = newNodes.get(foundNode);
+                    log.debug("Node was already found this round.");
+                  }
+                  if (nodes.containsKey(foundNode)) {
+                    foundNode = nodes.get(foundNode);
+                    log.debug("Its already in the node set.");
+                  }
+                  if (foundNode.colorsAreMergeable(lastNewNode.getColors()) &&
+                      foundNode.colorsAreMergeable(node.getColors())) {
+                    log.debug("Colors are mergeable.");
+                  } else {
+                    log.debug("Colors are not mergeable. Creating new node in graph");
+                    foundNode = new Node<>(content);
+                    foundNode.newId();
+                  }
                 }
-                if(nodes.containsKey(foundNode)){
-                  foundNode = nodes.get(foundNode);
-                  log.debug("Its already in the node set.");
-                }
-                if(foundNode.colorsAreMergeable(lastNewNode.getColors()) &&
-                  foundNode.colorsAreMergeable(node.getColors())){
-                  log.debug("Colors are mergeable. Will merge colors now.");
-                  foundNode.addColors(lastNewNode.getColors());
-                  foundNode.addColors(node.getColors());
-                } else{
-                  log.debug("Colors are not mergeable. Creating new node in graph");
-                  foundNode = new Node<>(content);
-                  foundNode.newId();
-                  foundNode.addColors(lastNewNode.getColors());
-                  foundNode.addColors(node.getColors());
-                }
+                foundNode.addColors(lastNewNode.getColors());
+                foundNode.addColors(node.getColors());
                 newNodes.put(foundNode, foundNode);
                 integrateNewNode(node, lastNewNode, foundNode);
               }

--- a/src/main/java/org/aksw/sessa/helper/graph/SelfBuildingGraph.java
+++ b/src/main/java/org/aksw/sessa/helper/graph/SelfBuildingGraph.java
@@ -6,9 +6,11 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import org.aksw.sessa.importing.rdf.SparqlGraphFiller;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * This class implements a graph, that builds itself using its node-contents to find new nodes. This
+ * This class implements a graph, that builds itself using its node content to find new nodes. This
  * is currently realized using {@link org.aksw.sessa.importing.rdf.SparqlGraphFiller}. The class
  * only searches for new nodes if every node has an explanation score.
  *
@@ -22,19 +24,21 @@ public class SelfBuildingGraph implements GraphInterface {
    */
   public static final int MAX_EXPANSIONS = 3;
   private int currentExpansion;
-  private Set<Node> nodes;
+  private Map<Node, Node> nodes;
 
   /**
    * We only want to update the graph with new information. Therefore we store the nodes that got
    * added after the last update
    */
-  private Set<Node> lastNewNodes;
+  private Map<Node, Node> lastNewNodes;
   private Map<Node, Set<Node>> edgeMap;
   private Map<Node, Set<Node>> reversedEdgeMap; // we need both ways (except for fact-nodes)
   private static int factIterator = 0;
 
   // Stores already compared key pairs so they don't get compared again
-  private HashMap<Node, Set<Node>> comparedNodes;
+  private Map<Node, Set<Node>> comparedNodes;
+
+  private static final Logger log = LoggerFactory.getLogger(GraphInterface.class);
 
 
   /**
@@ -48,10 +52,14 @@ public class SelfBuildingGraph implements GraphInterface {
    * Constructs a graph with given nodes.
    */
   public SelfBuildingGraph(Set<Node> nodes) {
-    this.nodes = nodes;
+    this.nodes = new HashMap<>();
+    this.lastNewNodes = new HashMap<>();
     this.edgeMap = new HashMap<>();
     this.reversedEdgeMap = new HashMap<>();
-    this.lastNewNodes = new HashSet<>(nodes);
+    for(Node node : nodes){
+      this.nodes.put(node, node);
+      this.lastNewNodes.put(node, node);
+    }
     this.comparedNodes = new HashMap<>();
     this.currentExpansion = 1;
   }
@@ -59,13 +67,13 @@ public class SelfBuildingGraph implements GraphInterface {
 
   @Override
   public void addNode(Node node) {
-    nodes.add(node);
-    lastNewNodes.add(node);
+    nodes.put(node, node);
+    lastNewNodes.put(node, node);
   }
 
   @Override
   public Set<Node> getNodes() {
-    return nodes;
+    return nodes.keySet();
   }
 
   @Override
@@ -127,7 +135,7 @@ public class SelfBuildingGraph implements GraphInterface {
    */
   private boolean everyNodeHasColor() {
     boolean everyNodeHasColor = true;
-    for (Node node : nodes) {
+    for (Node node : nodes.keySet()) {
       if (node.getColors().isEmpty()) {
         everyNodeHasColor = false;
         break;
@@ -145,15 +153,15 @@ public class SelfBuildingGraph implements GraphInterface {
    */
   protected void expandGraph() {
     if (currentExpansion <= MAX_EXPANSIONS) {
-      SparqlGraphFiller sgf = new SparqlGraphFiller();
-      Set<Node> newNodes = new HashSet<>();
+      SparqlGraphFiller filler = new SparqlGraphFiller();
+      Map<Node, Node> newNodes = new HashMap<>();
 
       // Copies of the node-sets so we can add nodes to the original ones
-      Set<Node> nodes = new HashSet<>(this.nodes);
-      Set<Node> lastNewNodes = new HashSet<>(this.lastNewNodes);
+      Map<Node, Node> nodes = new HashMap<>(this.nodes);
+      Map<Node, Node> lastNewNodes = new HashMap<>(this.lastNewNodes);
 
-      for (Node lastNewNode : lastNewNodes) {
-        for (Node node : nodes) {
+      for (Node lastNewNode : lastNewNodes.keySet()) {
+        for (Node node : nodes.keySet()) {
           if ((!comparedNodes.containsKey(lastNewNode) ||
               !comparedNodes.get(lastNewNode).contains(node)) &&
               !node.isFactNode()) {
@@ -163,13 +171,34 @@ public class SelfBuildingGraph implements GraphInterface {
             if (!node.getColors().isEmpty() &&
                 !lastNewNode.getColors().isEmpty() &&
                 !node.isOverlappingWith(lastNewNode)) {
-              Set<String> newContent = sgf.findMissingTripleElement(
+              Set<String> newContent = filler.findMissingTripleElement(
                   node.getContent().toString(),
                   lastNewNode.getContent().toString());
 
               for (String content : newContent) {
                 Node<String> foundNode = new Node<>(content);
-                newNodes.add(foundNode);
+                log.debug("SPARQL found new node {}", foundNode.getContent());
+                if(newNodes.containsKey(foundNode)){
+                  foundNode = newNodes.get(foundNode);
+                  log.debug("Node was already found this round.");
+                }
+                if(nodes.containsKey(foundNode)){
+                  foundNode = nodes.get(foundNode);
+                  log.debug("Its already in the node set.");
+                }
+                if(foundNode.colorsAreMergeable(lastNewNode.getColors()) &&
+                  foundNode.colorsAreMergeable(node.getColors())){
+                  log.debug("Colors are mergeable. Will merge colors now.");
+                  foundNode.addColors(lastNewNode.getColors());
+                  foundNode.addColors(node.getColors());
+                } else{
+                  log.debug("Colors are not mergeable. Creating new node in graph");
+                  foundNode = new Node<>(content);
+                  foundNode.newId();
+                  foundNode.addColors(lastNewNode.getColors());
+                  foundNode.addColors(node.getColors());
+                }
+                newNodes.put(foundNode, foundNode);
                 integrateNewNode(node, lastNewNode, foundNode);
               }
             }
@@ -218,6 +247,8 @@ public class SelfBuildingGraph implements GraphInterface {
     Node<Integer> factNode = new Node<>(factIterator);
     factIterator++;
     factNode.setNodeType(true);
+    factNode.addColors(node1.getColors());
+    factNode.addColors(node1.getColors());
     addNode(factNode);
     addNode(newNode);
     addEdge(factNode, node1);
@@ -238,7 +269,7 @@ public class SelfBuildingGraph implements GraphInterface {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("Nodes:\n");
-    for (Node node : nodes) {
+    for (Node node : nodes.keySet()) {
       sb.append("\t");
       sb.append(node.toString());
       sb.append("\n");

--- a/src/main/java/org/aksw/sessa/importing/dictionary/FileBasedDictionary.java
+++ b/src/main/java/org/aksw/sessa/importing/dictionary/FileBasedDictionary.java
@@ -59,8 +59,11 @@ public abstract class FileBasedDictionary implements DictionaryInterface {
     filteredCandidateSet.addAll(candidateSet);
     for (Filter filter : filterQue) {
       filteredCandidateSet = filter.filter(keyword, filteredCandidateSet);
-      log.debug("Used filter {} with result limit of {}. Got list: {}",
-          filter.getClass().getSimpleName(), filter.getNumberOfResults(), filteredCandidateSet);
+      log.debug("Used filter for keyword {} with {} with result limit of {}. Got list: {}",
+          keyword,
+          filter.getEnergyFunction().getClass().getSimpleName(),
+          filter.getNumberOfResults(),
+          filteredCandidateSet);
     }
     return filteredCandidateSet;
   }

--- a/src/main/java/org/aksw/sessa/importing/dictionary/util/Filter.java
+++ b/src/main/java/org/aksw/sessa/importing/dictionary/util/Filter.java
@@ -104,4 +104,10 @@ public class Filter {
     return numberOfResults;
   }
 
+  /**
+   *
+   */
+  public EnergyFunctionInterface getEnergyFunction() {
+    return energyFunction;
+  }
 }

--- a/src/main/java/org/aksw/sessa/query/models/NGramEntryPosition.java
+++ b/src/main/java/org/aksw/sessa/query/models/NGramEntryPosition.java
@@ -163,4 +163,21 @@ public class NGramEntryPosition {
     }
     return false;
   }
+
+  public boolean isMergeable(Set<NGramEntryPosition> otherColors){
+    boolean isMergeable = true;
+    for(NGramEntryPosition otherColor : otherColors){
+      if(!isMergeable(otherColor)){
+        isMergeable =  false;
+      }
+    }
+    return isMergeable;
+  }
+
+  public boolean isMergeable(NGramEntryPosition otherColor){
+    if(this.getLength() != otherColor.getLength()) {
+      return true;
+    }
+    return !this.isOverlappingWith(otherColor);
+  }
 }

--- a/src/main/java/org/aksw/sessa/query/models/NGramEntryPosition.java
+++ b/src/main/java/org/aksw/sessa/query/models/NGramEntryPosition.java
@@ -4,7 +4,11 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * This class represents a position in the n-gram hierarchy.
+ * This class represents a position in the n-gram hierarchy. A node with e.g. length of 2 and  third
+ * position (position=2) this object would represent the third bi-gram. If the whole n-gram is
+ * "birthplace bill gates wife", the object would represent "gates wife". Because this class is also
+ * used to describe which nodes are related in the graph, a NGramEntryPosition can also be seen als
+ * a color of a node.
  *
  * @author Simon Bordewisch
  */
@@ -23,7 +27,7 @@ public class NGramEntryPosition {
 
   /**
    * Initializes object with length and position in the "row". I.e. if e.g. length=2, position=2,
-   * this object would represent the third bigram. If the whole n-gram is "birthplace bill gates
+   * this object would represent the third bi-gram. If the whole n-gram is "birthplace bill gates
    * wife", the object would represent "gates wife".
    *
    * @param length length of the n-gram
@@ -131,6 +135,14 @@ public class NGramEntryPosition {
   }
 
 
+  /**
+   * Returns true if the given color is related to this color, i.e. if it is an ancestor or if the
+   * other color is an ancestor of this color.
+   *
+   * @param otherColor other color that should be checked for relation
+   * @return true if the given color is related to this color, false otherwise
+   * @see #isAncestorOf(NGramEntryPosition)
+   */
   public boolean isRelatedTo(NGramEntryPosition otherColor) {
     if (this.equals(otherColor)) {
       return true;
@@ -147,33 +159,66 @@ public class NGramEntryPosition {
     return false;
   }
 
+
+  /**
+   * Returns true if this color is an ancestor of the given color. A color is an ancestor of another
+   * node, if the node covers all words of the other node and is longer. For example, the color for
+   * "gates wife" would be an ancestor to the colors for "gates" and "wife".
+   *
+   * @param otherColor other color that should be checked if it is an descendant
+   * @return true if this color is an ancestor of the given color, false otherwise
+   */
   public boolean isAncestorOf(NGramEntryPosition otherColor) {
     return this.getAllDescendants().contains(otherColor);
   }
 
-  public boolean isOverlappingWith(NGramEntryPosition otherColor){
-    if(this.getPosition() <= otherColor.getPosition() &&
-        otherColor.getPosition() <= this.getPosition() + this.getLength() - 1){
+  /**
+   * Returns true if the represented positions of this color are overlapping with the represented
+   * positions of the given color. E.g. for the n-gram "birthplace bill gates wife", the color
+   * representing "birthplace bill" would overlap with the color representing "bill gates", because
+   * both cover the word "bill".
+   *
+   * @param otherColor color that should be compared with this color for overlaps
+   * @return true if the represented positions of this color are overlapping, false otherwise
+   */
+  public boolean isOverlappingWith(NGramEntryPosition otherColor) {
+    if (this.getPosition() <= otherColor.getPosition() &&
+        otherColor.getPosition() <= this.getPosition() + this.getLength() - 1) {
       return true;
     }
 
-    if(otherColor.getPosition() <= this.getPosition() &&
-        this.getPosition() <= otherColor.getPosition() + otherColor.getLength() - 1 ){
+    if (otherColor.getPosition() <= this.getPosition() &&
+        this.getPosition() <= otherColor.getPosition() + otherColor.getLength() - 1) {
       return true;
     }
     return false;
   }
 
-  public boolean isMergeable(Set<NGramEntryPosition> otherColors){
-    for(NGramEntryPosition otherColor : otherColors){
-      if(!isMergeable(otherColor)){
+  /**
+   * Returns true if the given set of colors is mergeable with this color. Also see {@link
+   * #isMergeable(NGramEntryPosition)}
+   *
+   * @param otherColors set of colors that should be checked for mergeability
+   * @return true if the given set of colors is mergeable with this color, false otherwise
+   * @see #isMergeable(NGramEntryPosition)
+   */
+  public boolean isMergeable(Set<NGramEntryPosition> otherColors) {
+    for (NGramEntryPosition otherColor : otherColors) {
+      if (!isMergeable(otherColor)) {
         return false;
       }
     }
     return true;
   }
 
-  public boolean isMergeable(NGramEntryPosition otherColor){
+  /**
+   * Returns true if the given set of colors is mergeable with this color. They are mergeable if
+   * they are related or don't overlap.
+   *
+   * @param otherColor set of colors that should be checked for mergeability
+   * @return true if the given color is mergeable with this color, false otherwise
+   */
+  public boolean isMergeable(NGramEntryPosition otherColor) {
     if (this.isRelatedTo(otherColor)) {
       return true;
     }

--- a/src/main/java/org/aksw/sessa/query/models/NGramEntryPosition.java
+++ b/src/main/java/org/aksw/sessa/query/models/NGramEntryPosition.java
@@ -165,13 +165,12 @@ public class NGramEntryPosition {
   }
 
   public boolean isMergeable(Set<NGramEntryPosition> otherColors){
-    boolean isMergeable = true;
     for(NGramEntryPosition otherColor : otherColors){
       if(!isMergeable(otherColor)){
-        isMergeable =  false;
+        return false;
       }
     }
-    return isMergeable;
+    return true;
   }
 
   public boolean isMergeable(NGramEntryPosition otherColor){

--- a/src/main/java/org/aksw/sessa/query/models/NGramEntryPosition.java
+++ b/src/main/java/org/aksw/sessa/query/models/NGramEntryPosition.java
@@ -175,7 +175,7 @@ public class NGramEntryPosition {
   }
 
   public boolean isMergeable(NGramEntryPosition otherColor){
-    if(this.getLength() != otherColor.getLength()) {
+    if (this.isRelatedTo(otherColor)) {
       return true;
     }
     return !this.isOverlappingWith(otherColor);

--- a/src/test/java/org/aksw/sessa/helper/graph/NodeTest.java
+++ b/src/test/java/org/aksw/sessa/helper/graph/NodeTest.java
@@ -1,5 +1,6 @@
 package org.aksw.sessa.helper.graph;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 
 import java.util.HashSet;
@@ -114,5 +115,21 @@ public class NodeTest {
 
     Assert.assertTrue(node1.isOverlappingWith(node2));
   }
+
+  @Test
+  public void testGetEnergy_WithConstructor(){
+    float energy = 2;
+    Node<Integer> node1 = new Node<Integer>(1, energy, null, false);
+    Assert.assertThat(node1.getEnergy(), equalTo(energy));
+  }
+
+  @Test
+  public void testGetEnergy_WithSet(){
+    float energy = 2;
+    Node<Integer> node1 = new Node<Integer>(1, 5, null, false);
+    node1.setEnergy(energy);
+    Assert.assertThat(node1.getEnergy(), equalTo(energy));
+  }
+
 
 }

--- a/src/test/java/org/aksw/sessa/main/SESSATest.java
+++ b/src/test/java/org/aksw/sessa/main/SESSATest.java
@@ -1,12 +1,15 @@
 package org.aksw.sessa.main;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.core.AllOf.allOf;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.hamcrest.core.IsNull.nullValue;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Set;
 import org.aksw.sessa.helper.files.handler.FileHandlerInterface;
 import org.aksw.sessa.helper.files.handler.TsvFileHandler;
@@ -71,6 +74,18 @@ public class SESSATest {
   }
 
   @Test
+  /**
+   * This test on issue #18.
+   */
+  public void testAnswer_onColorUpdateProblem() {
+    question = "offical language suriname";
+    answer = sessa.answer(question);
+    HashSet<String> answerSet = new HashSet<>();
+    answerSet.add("http://dbpedia.org/resource/Dutch_language");
+    Assert.assertThat(answer, equalTo(answerSet));
+  }
+
+  @Test
   public void testGetGraphFor_TestColors() {
     question = "music by elton john current production minskoff theatre";
     GraphInterface graph = sessa.getGraphFor(question);
@@ -80,6 +95,7 @@ public class SESSATest {
     }
     String answer = "http://dbpedia.org/resource/The_Lion_King_(musical)";
     Node answerNode = nodes.get(answer);
+    System.out.println(graph);
     Assert.assertThat(answerNode.getExplanation(), equalTo(question.split(" ").length));
   }
   // TODO: create tests for other questions

--- a/src/test/java/org/aksw/sessa/query/models/NGramEntryPositionTest.java
+++ b/src/test/java/org/aksw/sessa/query/models/NGramEntryPositionTest.java
@@ -1,6 +1,8 @@
 package org.aksw.sessa.query.models;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -11,6 +13,20 @@ import org.junit.Test;
  * Created by Simon Bordewisch on 16.06.17.
  */
 public class NGramEntryPositionTest {
+
+
+  @Test
+  public void TestEquals_Equal() {
+    NGramEntryPosition pos1 = new NGramEntryPosition(3, 1);
+    Assert.assertThat(pos1, equalTo(pos1));
+  }
+
+  @Test
+  public void TestEquals_Different() {
+    NGramEntryPosition pos1 = new NGramEntryPosition(3, 1);
+    NGramEntryPosition pos2 = new NGramEntryPosition(3, 2);
+    Assert.assertThat(pos1, not(equalTo(pos2)));
+  }
 
 
   @Test
@@ -151,6 +167,56 @@ public class NGramEntryPositionTest {
     NGramEntryPosition pos2 = new NGramEntryPosition(1, 4);
     Assert.assertThat(pos2.isOverlappingWith(pos1), is(false));
     Assert.assertThat(pos1.isOverlappingWith(pos2), is(false));
+  }
+
+  @Test
+  public void TestIsMergeable_True1() {
+    NGramEntryPosition pos1 = new NGramEntryPosition(1, 2);
+    NGramEntryPosition pos2 = new NGramEntryPosition(1, 4);
+    Assert.assertThat(pos2.isMergeable(pos1), is(true));
+  }
+
+  @Test
+  public void TestIsMergeable_True2() {
+    NGramEntryPosition pos1 = new NGramEntryPosition(2, 1);
+    NGramEntryPosition pos2 = new NGramEntryPosition(1, 2);
+    Assert.assertThat(pos2.isMergeable(pos1), is(true));
+  }
+
+  @Test
+  public void TestIsMergeable_False1() {
+    NGramEntryPosition pos1 = new NGramEntryPosition(2, 1);
+    NGramEntryPosition pos2 = new NGramEntryPosition(2, 2);
+    Assert.assertThat(pos2.isMergeable(pos1), is(false));
+  }
+
+  @Test
+  public void TestIsMergeable_False3() {
+    NGramEntryPosition pos1 = new NGramEntryPosition(3, 1);
+    NGramEntryPosition pos2 = new NGramEntryPosition(2, 3);
+    Assert.assertThat(pos2.isMergeable(pos1), is(false));
+  }
+
+  @Test
+  public void TestIsMergeable_ForSet_True1() {
+    NGramEntryPosition pos1 = new NGramEntryPosition(3, 0);
+    NGramEntryPosition pos2 = new NGramEntryPosition(2, 3);
+    NGramEntryPosition pos3 = new NGramEntryPosition(2, 5);
+    HashSet<NGramEntryPosition> set = new HashSet<>();
+    set.add(pos2);
+    set.add(pos3);
+    Assert.assertThat(pos1.isMergeable(set), is(true));
+  }
+
+  @Test
+  public void TestIsMergeable_ForSet_False1() {
+    NGramEntryPosition pos1 = new NGramEntryPosition(3, 0);
+    NGramEntryPosition pos2 = new NGramEntryPosition(2, 2);
+    NGramEntryPosition pos3 = new NGramEntryPosition(2, 5);
+    HashSet<NGramEntryPosition> set = new HashSet<>();
+    set.add(pos2);
+    set.add(pos3);
+    Assert.assertThat(pos1.isMergeable(set), is(false));
   }
 
 }

--- a/src/test/resources/en_surface_forms_small.tsv
+++ b/src/test/resources/en_surface_forms_small.tsv
@@ -284,3 +284,6 @@ http://dbpedia.org/ontology/musicBy	music by
 http://dbpedia.org/ontology/currentProduction	current production
 http://dbpedia.org/resource/Minskoff_Theatre	minskoff theatre
 http://dbpedia.org/resource/Andriy_Hitchenko	hitchenko
+http://dbpedia.org/resource/Suriname	suriname
+http://dbpedia.org/ontology/officialLanguage	offical language
+http://dbpedia.org/ontology/language	language


### PR DESCRIPTION
Now instead of updating the colors of the new nodes after each add-cycle, they are updated immediately.

This introduces the complication that later in the graph-building cycle, further nodes could point to a node and we want the better one. Therefore new methods are introduced in the Node-class which check if the colors are "mergeable" and if they would produce a better explanation score, the node is updated with the new colors.