### PR TITLE
Use HTTPS to resolve dependencies in Maven Build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,12 +79,12 @@
     <repository>
       <id>maven.aksw.snapshots</id>
       <name>AKSW Snapshot Repository</name>
-      <url>http://maven.aksw.org/archiva/repository/snapshots</url>
+      <url>https://maven.aksw.org/archiva/repository/snapshots</url>
     </repository>
     <repository>
       <id>maven.aksw.internal</id>
       <name>University Leipzig, AKSW Maven2 Repository</name>
-      <url>http://maven.aksw.org/archiva/repository/internal</url>
+      <url>https://maven.aksw.org/archiva/repository/internal</url>
     </repository>
     <repository>
       <id>central</id>


### PR DESCRIPTION
Resolve dependencies of the AKSW repository over https.